### PR TITLE
fix ambiguous abbreviation

### DIFF
--- a/sdid.ado
+++ b/sdid.ado
@@ -616,7 +616,7 @@ if length("`returnweights'")!=0 {
         }
         local ++i
     }
-    varabbrev ren c `3'
+    varabbrev ren c`i' `3'
     tempfile dlambda
     qui save `dlambda'
     restore
@@ -632,7 +632,7 @@ if length("`returnweights'")!=0 {
 	    ren c`i' `generate'omega`t'
         local ++i
     }
-    varabbrev ren c `2'
+    varabbrev ren c`i' `2'
     tempfile domega
     qui save `domega'
     restore


### PR DESCRIPTION
the returnweights sequence fails if a user has set varabbrev off. the loops that proceed the problematic renames provide a correct increment of the local used to track the exact variable name that needs a rename. I added the local to the end of the rename target variable, fixing this behavior for varabbrev off users.